### PR TITLE
Fix possible invalid index

### DIFF
--- a/wallpaper.el
+++ b/wallpaper.el
@@ -160,7 +160,7 @@ may interfere with its proper behavior.")
 ;; In my opinion this should be named `wallpaper-set-random-wallpaper'.  Seeing
 ;; this I would think that this is an interactive function to choose the
 ;; wallpaper.  In fact, even reading the doc-string would make me thing that
-;; because it just says "set the wallpaper". It should at least say "set "
+;; because it just says "set the wallpaper".
 
 ;; It's a matter of opinion whether by "set a random wallpaper" the user means
 ;; set a random wallpaper that's not the current one.  To be honest that's what

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -222,7 +222,7 @@ If `wallpaper-cycle-single' is non-nil, only one wallpaper is returned."
          (num-monitors (if wallpaper-cycle-single 1 (wallpaper--num-monitors)))
          (wallpapers nil))
     (dotimes (_ num-monitors)
-      (let ((wallpaper (nth (random num-available) available)))
+      (let ((wallpaper (nth (1- (random num-available)) available)))
         (cl-pushnew wallpaper wallpapers)
         (setq available (delq wallpaper available))))
     wallpapers))

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -181,11 +181,11 @@ This function will either choose a random wallpaper from
         (command (concat "feh --no-fehbg " (wallpaper--background))))
     (if (not wallpapers)
         (message "No wallpapers selected.")
-      (dolist (wallpaper (-difference wallpapers wallpaper-current-wallpapers))
+      (setq wallpaper-current-wallpapers nil)
+      (dolist (wallpaper wallpapers)
         (alet (expand-file-name (shell-quote-argument (f-filename wallpaper)) (f-dirname wallpaper))
           (setq command (concat command (wallpaper--scaling) it " ")))
         (add-to-list 'wallpaper-current-wallpapers wallpaper))
-      (setq wallpaper-current-wallpapers nil)
       (start-process-shell-command "Wallpaper" nil command))))
 
 ;; I get the feeling the naming system should be more consistent.  We have

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -157,6 +157,8 @@ The default option is fill."
 This variable is set automatically.  Hand modification of its value
 may interfere with its proper behavior.")
 
+;; In my opinion this should be named `wallpaper-set-random-wallpaper'.  Seeing
+;; this I would think that this is 
 ;;;###autoload
 (defun wallpaper-set-wallpaper ()
   "Set the wallpaper.

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -160,6 +160,11 @@ may interfere with its proper behavior.")
 ;; In my opinion this should be named `wallpaper-set-random-wallpaper'.  Seeing
 ;; this I would think that this is an interactive function to choose the
 ;; wallpaper.
+
+;; It's a matter of opinion whether by "set a random wallpaper" the user means
+;; set a random wallpaper that's not the current one.  To be honest that's what
+;; I mean when I say that.  I mean why would I even call this command if I'm
+;; O.K. with the same wallpaper?
 ;;;###autoload
 (defun wallpaper-set-wallpaper ()
   "Set the wallpaper.

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -160,7 +160,8 @@ may interfere with its proper behavior.")
 ;; In my opinion this should be named `wallpaper-set-random-wallpaper'.  Seeing
 ;; this I would think that this is an interactive function to choose the
 ;; wallpaper.  In fact, even reading the doc-string would make me thing that
-;; because it just says "set the wallpaper".
+;; because it just says "set the wallpaper".  It should at least say "set random
+;; wallpaper".
 
 ;; It's a matter of opinion whether by "set a random wallpaper" the user means
 ;; set a random wallpaper that's not the current one.  To be honest that's what

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -160,7 +160,7 @@ may interfere with its proper behavior.")
 ;; In my opinion this should be named `wallpaper-set-random-wallpaper'.  Seeing
 ;; this I would think that this is an interactive function to choose the
 ;; wallpaper.  In fact, even reading the doc-string would make me thing that
-;; because 
+;; because it just says "set the wallpaper". It should at least say "set "
 
 ;; It's a matter of opinion whether by "set a random wallpaper" the user means
 ;; set a random wallpaper that's not the current one.  To be honest that's what

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -167,8 +167,6 @@ may interfere with its proper behavior.")
 ;; set a random wallpaper that's not the current one.  To be honest that's what
 ;; I mean when I say that.  I mean why would I even call this command if I'm
 ;; O.K. with the same wallpaper?
-
-;; This monitor stuff is confusing me.
 ;;;###autoload
 (defun wallpaper-set-wallpaper ()
   "Set the wallpaper to a random different wallpaper.

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -173,10 +173,10 @@ This function will either choose a random wallpaper from
         (message "No wallpapers selected.")
       (setq wallpaper-current-wallpapers nil)
       (dolist (wallpaper wallpapers)
-        (setq command (concat command (wallpaper--scaling) wallpaper " "))
+        (alet (expand-file-name (shell-quote-argument (f-filename wallpaper)) (f-dirname wallpaper))
+          (setq command (concat command (wallpaper--scaling) it " ")))
         (add-to-list 'wallpaper-current-wallpapers wallpaper))
-      (start-process-shell-command
-       "Wallpaper" nil command))))
+      (start-process-shell-command "Wallpaper" nil command))))
 
 
 

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -181,11 +181,11 @@ This function will either choose a random wallpaper from
         (command (concat "feh --no-fehbg " (wallpaper--background))))
     (if (not wallpapers)
         (message "No wallpapers selected.")
-      (setq wallpaper-current-wallpapers nil)
-      (dolist (wallpaper (remove wallpapers))
+      (dolist (wallpaper (-difference wallpapers wallpaper-current-wallpapers))
         (alet (expand-file-name (shell-quote-argument (f-filename wallpaper)) (f-dirname wallpaper))
           (setq command (concat command (wallpaper--scaling) it " ")))
         (add-to-list 'wallpaper-current-wallpapers wallpaper))
+      (setq wallpaper-current-wallpapers nil)
       (start-process-shell-command "Wallpaper" nil command))))
 
 ;; I get the feeling the naming system should be more consistent.  We have

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -169,7 +169,7 @@ may interfere with its proper behavior.")
 ;; O.K. with the same wallpaper?
 ;;;###autoload
 (defun wallpaper-set-wallpaper ()
-  "Set the wallpaper.
+  "Set the wallpaper to a random different wallpaper.
 
 This function will either choose a random wallpaper from
 `wallpaper-cycle-directory' or use the wallpapers listed in

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -178,6 +178,38 @@ This function will either choose a random wallpaper from
         (add-to-list 'wallpaper-current-wallpapers wallpaper))
       (start-process-shell-command "Wallpaper" nil command))))
 
+;; I get the feeling the naming system should be more consistent.  We have
+;; `wallpaper--random-wallpapers' and `wallpaper--get-available'.  Either we
+;; match it with `wallpaper--available-wallpapers` or do
+;; `wallpaper--get-random`, no?  Also I'm not such a fan of the functionality of
+;; `wallpaper--random-wallpapers'.  By reading the name I would think it gives
+;; me a list of random wallpapers from the available wallpapers; but instead it
+;; gives me a random wallpaper for each monitor.  I feel that "monitor" should
+;; be in its name if it's a monitor specific function.
+
+;; Surprisingly, there's no interactive function to actually choose a wallpaper.
+;; I feel that this is a basic thing that should be here.
+
+;; Choose a wallpaper.  I don't completely understand how there are multiple
+;; wallpapers in `wallpaper-set-wallpapers'.  Aren't we just setting one?  The
+;; current monitor's?  In any case, I'll follow the idiom.
+(defun wallpaper-choose-wallpaper ()
+  "Choose a wallpaper for current monitor."
+  (interactive)
+  (let ((wallpapers (or (wallpaper--per-workspace-wallpapers)
+                        wallpaper-static-wallpaper-list
+                        (wallpaper--get-available)))
+        (wallpaper nil)
+        (command (concat "feh --no-fehbg " (wallpaper--background))))
+    (if (not wallpapers)
+        (message "No wallpapers to choose from.")
+      (setq wallpaper-current-wallpapers nil)
+      (setq wallpaper (completing-read "wallpaper: " wallpapers))
+      (alet (expand-file-name (shell-quote-argument (f-filename wallpaper)) (f-dirname wallpaper))
+        (setq command  (concat command (wallpaper--scaling) it)))
+      (add-to-list 'wallpaper-current-wallpapers wallpaper)
+      (start-process-shell-command "Wallpaper" nil command))))
+
 
 
 (defun wallpaper--scaling ()

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -159,7 +159,8 @@ may interfere with its proper behavior.")
 
 ;; In my opinion this should be named `wallpaper-set-random-wallpaper'.  Seeing
 ;; this I would think that this is an interactive function to choose the
-;; wallpaper.
+;; wallpaper.  In fact, even reading the doc-string would make me thing that
+;; because 
 
 ;; It's a matter of opinion whether by "set a random wallpaper" the user means
 ;; set a random wallpaper that's not the current one.  To be honest that's what

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -182,7 +182,7 @@ This function will either choose a random wallpaper from
     (if (not wallpapers)
         (message "No wallpapers selected.")
       (setq wallpaper-current-wallpapers nil)
-      (dolist (wallpaper wallpapers)
+      (dolist (wallpaper (remove wallpapers))
         (alet (expand-file-name (shell-quote-argument (f-filename wallpaper)) (f-dirname wallpaper))
           (setq command (concat command (wallpaper--scaling) it " ")))
         (add-to-list 'wallpaper-current-wallpapers wallpaper))

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -167,6 +167,10 @@ may interfere with its proper behavior.")
 ;; set a random wallpaper that's not the current one.  To be honest that's what
 ;; I mean when I say that.  I mean why would I even call this command if I'm
 ;; O.K. with the same wallpaper?
+
+;; This monitor stuff is confusing me.  I think it's makes things more
+;; complicated than what its worth.  I don't use multiple monitors but if I did
+;; would I really want to change all their wallpapers at the same time?
 ;;;###autoload
 (defun wallpaper-set-wallpaper ()
   "Set the wallpaper to a random different wallpaper.

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -158,7 +158,8 @@ This variable is set automatically.  Hand modification of its value
 may interfere with its proper behavior.")
 
 ;; In my opinion this should be named `wallpaper-set-random-wallpaper'.  Seeing
-;; this I would think that this is 
+;; this I would think that this is an interactive function to choose the
+;; wallpaper.
 ;;;###autoload
 (defun wallpaper-set-wallpaper ()
   "Set the wallpaper.

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -167,6 +167,8 @@ may interfere with its proper behavior.")
 ;; set a random wallpaper that's not the current one.  To be honest that's what
 ;; I mean when I say that.  I mean why would I even call this command if I'm
 ;; O.K. with the same wallpaper?
+
+;; This monitor stuff is confusing me.
 ;;;###autoload
 (defun wallpaper-set-wallpaper ()
   "Set the wallpaper to a random different wallpaper.

--- a/wallpaper.el
+++ b/wallpaper.el
@@ -181,11 +181,14 @@ This function will either choose a random wallpaper from
 ;; I get the feeling the naming system should be more consistent.  We have
 ;; `wallpaper--random-wallpapers' and `wallpaper--get-available'.  Either we
 ;; match it with `wallpaper--available-wallpapers` or do
-;; `wallpaper--get-random`, no?  Also I'm not such a fan of the functionality of
-;; `wallpaper--random-wallpapers'.  By reading the name I would think it gives
-;; me a list of random wallpapers from the available wallpapers; but instead it
-;; gives me a random wallpaper for each monitor.  I feel that "monitor" should
-;; be in its name if it's a monitor specific function.
+;; `wallpaper--get-random`, no?
+
+;; Also I'm not such a fan of the functionality of
+;; `wallpaper--random-wallpapers' relative to its name.  By reading the name I
+;; would think it gives me a list of random wallpapers from the available
+;; wallpapers; but instead it gives me a random wallpaper for each monitor.  I
+;; feel that "monitor" should be in its name if it's a monitor specific
+;; function.
 
 ;; Surprisingly, there's no interactive function to actually choose a wallpaper.
 ;; I feel that this is a basic thing that should be here.
@@ -206,7 +209,7 @@ This function will either choose a random wallpaper from
       (setq wallpaper-current-wallpapers nil)
       (setq wallpaper (completing-read "wallpaper: " wallpapers))
       (alet (expand-file-name (shell-quote-argument (f-filename wallpaper)) (f-dirname wallpaper))
-        (setq command  (concat command (wallpaper--scaling) it)))
+        (setq command (concat command (wallpaper--scaling) it)))
       (add-to-list 'wallpaper-current-wallpapers wallpaper)
       (start-process-shell-command "Wallpaper" nil command))))
 


### PR DESCRIPTION
Hi, 
I think there's a bug in `wallpaper--random-wallpapers`.  Specifically, with the form `(nth (random num-available) available)`.  The symbol `num-available` stores `(length available)` but nth takes an index.  So it is possible for `(random num-available)` to exceed the valid indices.  In which case, no wallpaper would be set.  In this PR I fix this but I also have other things I'm working on (which I can remove should you want to merge).  I am mainly sending this to see if you are open to PRs.